### PR TITLE
Scaffold Swift package with formatting config

### DIFF
--- a/.swift-format.json
+++ b/.swift-format.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "lineLength": 100,
+  "indentation": {
+    "spaces": 4
+  },
+  "respectsExistingLineBreaks": true,
+  "rules": {
+    "DoNotUseSemicolons": true,
+    "UseLetInEveryBoundCaseVariable": true
+  }
+}

--- a/Examples/DashboardDemo/main.swift
+++ b/Examples/DashboardDemo/main.swift
@@ -1,0 +1,15 @@
+import SwiftCursesKit
+
+/// Bootstraps the minimal dashboard demo.
+@main
+struct DashboardDemo {
+    static func main() {
+        do {
+            let app = TerminalApp()
+            let banner = try app.run()
+            print("Launching: \(banner)")
+        } catch {
+            print("Failed to start SwiftCursesKit demo: \(error)")
+        }
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,40 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "SwiftCursesKit",
+    platforms: [
+        .macOS(.v13),
+        .tvOS(.v13),
+        .iOS(.v16),
+        .watchOS(.v9),
+        .visionOS(.v1),
+    ],
+    products: [
+        .library(
+            name: "SwiftCursesKit",
+            targets: ["SwiftCursesKit"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "SwiftCursesKit",
+            dependencies: ["CNCursesSupport"],
+            path: "Sources/SwiftCursesKit"
+        ),
+        .target(
+            name: "CNCursesSupport",
+            path: "Sources/CNCursesSupport"
+        ),
+        .executableTarget(
+            name: "DashboardDemo",
+            dependencies: ["SwiftCursesKit"],
+            path: "Examples/DashboardDemo"
+        ),
+        .testTarget(
+            name: "SwiftCursesKitTests",
+            dependencies: ["SwiftCursesKit"],
+            path: "Tests/SwiftCursesKitTests"
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -125,8 +125,17 @@ Refer to `AGENTS.md` for detailed contribution standards.
 ```bash
 swift build
 swift test
-swift-format --in-place .
+swift-format --configuration .swift-format.json --in-place .
 swift run Examples/DashboardDemo
+```
+
+### Formatting
+
+The repository includes a shared `.swift-format.json` profile. Apply it before committing to
+keep whitespace and line wrapping consistent across all targets:
+
+```bash
+swift-format --configuration .swift-format.json --in-place .
 ```
 
 Before submitting a pull request:

--- a/Sources/CNCursesSupport/Bootstrap.swift
+++ b/Sources/CNCursesSupport/Bootstrap.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// A lightweight shim that stands in for ncurses bootstrapping during early development.
+package struct CNCursesRuntime {
+    /// Returns `true` to indicate the terminal runtime was prepared successfully.
+    package static func bootstrap() throws -> Bool {
+        // This placeholder implementation simulates runtime initialization.
+        return true
+    }
+}

--- a/Sources/SwiftCursesKit/TerminalApp.swift
+++ b/Sources/SwiftCursesKit/TerminalApp.swift
@@ -1,0 +1,34 @@
+import Foundation
+import CNCursesSupport
+
+/// Represents the entry point for a SwiftCursesKit powered application.
+public struct TerminalApp {
+    /// The textual banner presented when the demo app is launched.
+    public var banner: String
+
+    /// Creates a new terminal application descriptor.
+    /// - Parameter banner: The title that should be displayed when the app launches.
+    public init(banner: String = "SwiftCursesKit Demo") {
+        self.banner = banner
+    }
+
+    /// Prepares the terminal runtime and returns the banner text on success.
+    ///
+    /// This placeholder implementation allows unit tests and examples to validate the
+    /// package wiring before the real ncurses integration is in place.
+    /// - Returns: The banner text that callers can display to a user.
+    @discardableResult
+    public func run() throws -> String {
+        let isReady = try CNCursesRuntime.bootstrap()
+        guard isReady else {
+            throw TerminalRuntimeError.bootstrapFailed
+        }
+        return banner
+    }
+}
+
+/// Errors thrown by the terminal runtime bootstrapper.
+public enum TerminalRuntimeError: Error, Equatable {
+    /// Indicates that the ncurses layer failed to initialize.
+    case bootstrapFailed
+}

--- a/Tests/SwiftCursesKitTests/TerminalAppTests.swift
+++ b/Tests/SwiftCursesKitTests/TerminalAppTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import SwiftCursesKit
+
+final class TerminalAppTests: XCTestCase {
+    func testRunReturnsBanner() throws {
+        let app = TerminalApp(banner: "Test Banner")
+        let output = try app.run()
+        XCTAssertEqual(output, "Test Banner")
+    }
+}


### PR DESCRIPTION
## Summary
- add the SwiftPM manifest with the SwiftCursesKit library, CNCursesSupport shim, and DashboardDemo example target
- scaffold initial source, example, and test files that compile against the placeholder runtime
- introduce a shared swift-format configuration and document how to apply it in the README

## Testing
- swift build
- swift test
- swift-format format --configuration .swift-format.json --in-place --recursive Package.swift Sources Examples Tests

------
https://chatgpt.com/codex/tasks/task_b_68ce5e6b4be48333b65825380c33b938