### PR TITLE
Add async event stream and input handling

### DIFF
--- a/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
+++ b/Sources/CNCursesSupport/Shims/include/CNCursesSupportShims.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <ncursesw/curses.h>
+#include <wchar.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,6 +35,232 @@ static inline int32_t cncurses_noecho(void) {
 
 static inline int32_t cncurses_keypad(CNCursesWindowRef window, bool enable) {
     return (int32_t)keypad((WINDOW *)window, enable ? TRUE : FALSE);
+}
+
+static inline int32_t cncurses_nodelay(CNCursesWindowRef window, bool enable) {
+    return (int32_t)nodelay((WINDOW *)window, enable ? TRUE : FALSE);
+}
+
+static inline int32_t cncurses_wget_wch(CNCursesWindowRef window, uint32_t *value) {
+    wint_t ch = 0;
+    int32_t result = (int32_t)wget_wch((WINDOW *)window, &ch);
+    if (value != NULL) {
+        *value = (uint32_t)ch;
+    }
+    return result;
+}
+
+static inline bool cncurses_has_mouse(void) {
+    return has_mouse() ? true : false;
+}
+
+typedef struct {
+    int16_t identifier;
+    int32_t x;
+    int32_t y;
+    int32_t z;
+    uint64_t state;
+} CNCursesMouseEvent;
+
+static inline int32_t cncurses_getmouse(CNCursesMouseEvent *event) {
+    MEVENT rawEvent;
+    int32_t result = (int32_t)getmouse(&rawEvent);
+    if (result == ERR) {
+        return result;
+    }
+    if (event != NULL) {
+        event->identifier = rawEvent.id;
+        event->x = rawEvent.x;
+        event->y = rawEvent.y;
+        event->z = rawEvent.z;
+        event->state = (uint64_t)rawEvent.bstate;
+    }
+    return result;
+}
+
+static inline uint64_t cncurses_mousemask(uint64_t newmask, uint64_t *oldmask) {
+    mmask_t previousMask = 0;
+    mmask_t result = mousemask((mmask_t)newmask, oldmask != NULL ? &previousMask : NULL);
+    if (oldmask != NULL) {
+        *oldmask = (uint64_t)previousMask;
+    }
+    return (uint64_t)result;
+}
+
+static inline uint32_t cncurses_key_code_yes(void) {
+    return (uint32_t)KEY_CODE_YES;
+}
+
+static inline uint32_t cncurses_key_mouse(void) {
+    return (uint32_t)KEY_MOUSE;
+}
+
+static inline uint32_t cncurses_key_resize(void) {
+    return (uint32_t)KEY_RESIZE;
+}
+
+static inline uint32_t cncurses_key_enter(void) {
+    return (uint32_t)KEY_ENTER;
+}
+
+static inline uint32_t cncurses_key_backspace(void) {
+    return (uint32_t)KEY_BACKSPACE;
+}
+
+static inline uint32_t cncurses_key_up(void) {
+    return (uint32_t)KEY_UP;
+}
+
+static inline uint32_t cncurses_key_down(void) {
+    return (uint32_t)KEY_DOWN;
+}
+
+static inline uint32_t cncurses_key_left(void) {
+    return (uint32_t)KEY_LEFT;
+}
+
+static inline uint32_t cncurses_key_right(void) {
+    return (uint32_t)KEY_RIGHT;
+}
+
+static inline uint32_t cncurses_key_home(void) {
+    return (uint32_t)KEY_HOME;
+}
+
+static inline uint32_t cncurses_key_end(void) {
+    return (uint32_t)KEY_END;
+}
+
+static inline uint32_t cncurses_key_npage(void) {
+    return (uint32_t)KEY_NPAGE;
+}
+
+static inline uint32_t cncurses_key_ppage(void) {
+    return (uint32_t)KEY_PPAGE;
+}
+
+static inline uint32_t cncurses_key_ic(void) {
+    return (uint32_t)KEY_IC;
+}
+
+static inline uint32_t cncurses_key_dc(void) {
+    return (uint32_t)KEY_DC;
+}
+
+static inline uint32_t cncurses_key_btab(void) {
+    return (uint32_t)KEY_BTAB;
+}
+
+static inline uint32_t cncurses_key_f(int32_t index) {
+    return (uint32_t)KEY_F(index);
+}
+
+static inline uint64_t cncurses_all_mouse_events(void) {
+    return (uint64_t)ALL_MOUSE_EVENTS;
+}
+
+static inline uint64_t cncurses_report_mouse_position(void) {
+    return (uint64_t)REPORT_MOUSE_POSITION;
+}
+
+static inline uint64_t cncurses_button1_pressed(void) {
+    return (uint64_t)BUTTON1_PRESSED;
+}
+
+static inline uint64_t cncurses_button1_released(void) {
+    return (uint64_t)BUTTON1_RELEASED;
+}
+
+static inline uint64_t cncurses_button1_clicked(void) {
+    return (uint64_t)BUTTON1_CLICKED;
+}
+
+static inline uint64_t cncurses_button1_double_clicked(void) {
+    return (uint64_t)BUTTON1_DOUBLE_CLICKED;
+}
+
+static inline uint64_t cncurses_button1_triple_clicked(void) {
+    return (uint64_t)BUTTON1_TRIPLE_CLICKED;
+}
+
+static inline uint64_t cncurses_button2_pressed(void) {
+    return (uint64_t)BUTTON2_PRESSED;
+}
+
+static inline uint64_t cncurses_button2_released(void) {
+    return (uint64_t)BUTTON2_RELEASED;
+}
+
+static inline uint64_t cncurses_button2_clicked(void) {
+    return (uint64_t)BUTTON2_CLICKED;
+}
+
+static inline uint64_t cncurses_button2_double_clicked(void) {
+    return (uint64_t)BUTTON2_DOUBLE_CLICKED;
+}
+
+static inline uint64_t cncurses_button2_triple_clicked(void) {
+    return (uint64_t)BUTTON2_TRIPLE_CLICKED;
+}
+
+static inline uint64_t cncurses_button3_pressed(void) {
+    return (uint64_t)BUTTON3_PRESSED;
+}
+
+static inline uint64_t cncurses_button3_released(void) {
+    return (uint64_t)BUTTON3_RELEASED;
+}
+
+static inline uint64_t cncurses_button3_clicked(void) {
+    return (uint64_t)BUTTON3_CLICKED;
+}
+
+static inline uint64_t cncurses_button3_double_clicked(void) {
+    return (uint64_t)BUTTON3_DOUBLE_CLICKED;
+}
+
+static inline uint64_t cncurses_button3_triple_clicked(void) {
+    return (uint64_t)BUTTON3_TRIPLE_CLICKED;
+}
+
+static inline uint64_t cncurses_button4_pressed(void) {
+    return (uint64_t)BUTTON4_PRESSED;
+}
+
+static inline uint64_t cncurses_button5_pressed(void) {
+    return (uint64_t)BUTTON5_PRESSED;
+}
+
+#ifdef BUTTON6_PRESSED
+static inline uint64_t cncurses_button6_pressed(void) {
+    return (uint64_t)BUTTON6_PRESSED;
+}
+#else
+static inline uint64_t cncurses_button6_pressed(void) {
+    return 0;
+}
+#endif
+
+#ifdef BUTTON7_PRESSED
+static inline uint64_t cncurses_button7_pressed(void) {
+    return (uint64_t)BUTTON7_PRESSED;
+}
+#else
+static inline uint64_t cncurses_button7_pressed(void) {
+    return 0;
+}
+#endif
+
+static inline uint64_t cncurses_button_shift(void) {
+    return (uint64_t)BUTTON_SHIFT;
+}
+
+static inline uint64_t cncurses_button_ctrl(void) {
+    return (uint64_t)BUTTON_CTRL;
+}
+
+static inline uint64_t cncurses_button_alt(void) {
+    return (uint64_t)BUTTON_ALT;
 }
 
 static inline int32_t cncurses_refresh(void) {

--- a/Sources/CNCursesSupport/Swift/Input.swift
+++ b/Sources/CNCursesSupport/Swift/Input.swift
@@ -1,0 +1,111 @@
+@_implementationOnly import CNCursesSupportShims
+
+package enum CNCursesInputAPI {
+  package enum ReadResult: Equatable {
+    case none
+    case character(UInt32)
+    case keyCode(UInt32)
+  }
+
+  package static func readEvent(from descriptor: CNCursesWindowDescriptor) -> ReadResult {
+    var value: UInt32 = 0
+    let result = cncurses_wget_wch(descriptor.rawValue, &value)
+    if result == cncurses_error() {
+      return .none
+    }
+    if UInt32(result) == CNCursesKeyCode.codeYes {
+      return .keyCode(value)
+    }
+    return .character(value)
+  }
+
+  package static func enableNonBlockingInput(for descriptor: CNCursesWindowDescriptor) throws {
+    try CNCursesCall.check(result: cncurses_nodelay(descriptor.rawValue, true), name: "nodelay")
+  }
+
+  package static func enableMouseReporting() {
+    guard cncurses_has_mouse() else { return }
+    _ = cncurses_mousemask(
+      cncurses_all_mouse_events() | cncurses_report_mouse_position(),
+      nil
+    )
+  }
+
+  package static func nextMouseEvent() -> CNCursesMouseEvent? {
+    var raw = CNCursesSupportShims.CNCursesMouseEvent(identifier: 0, x: 0, y: 0, z: 0, state: 0)
+    let result = withUnsafeMutablePointer(to: &raw) { pointer in
+      cncurses_getmouse(pointer)
+    }
+    if result == cncurses_error() {
+      return nil
+    }
+    return CNCursesMouseEvent(
+      identifier: raw.identifier,
+      x: raw.x,
+      y: raw.y,
+      z: raw.z,
+      state: raw.state
+    )
+  }
+}
+
+package enum CNCursesKeyCode {
+  package static let codeYes: UInt32 = cncurses_key_code_yes()
+  package static let mouse: UInt32 = cncurses_key_mouse()
+  package static let resize: UInt32 = cncurses_key_resize()
+  package static let enter: UInt32 = cncurses_key_enter()
+  package static let backspace: UInt32 = cncurses_key_backspace()
+  package static let up: UInt32 = cncurses_key_up()
+  package static let down: UInt32 = cncurses_key_down()
+  package static let left: UInt32 = cncurses_key_left()
+  package static let right: UInt32 = cncurses_key_right()
+  package static let home: UInt32 = cncurses_key_home()
+  package static let end: UInt32 = cncurses_key_end()
+  package static let pageDown: UInt32 = cncurses_key_npage()
+  package static let pageUp: UInt32 = cncurses_key_ppage()
+  package static let insert: UInt32 = cncurses_key_ic()
+  package static let delete: UInt32 = cncurses_key_dc()
+  package static let backTab: UInt32 = cncurses_key_btab()
+
+  package static func function(_ index: Int) -> UInt32 {
+    cncurses_key_f(Int32(index))
+  }
+}
+
+package struct CNCursesMouseEvent: Sendable {
+  package let identifier: Int16
+  package let x: Int32
+  package let y: Int32
+  package let z: Int32
+  package let state: UInt64
+}
+
+package enum CNCursesMouseMask {
+  package static let reportPosition: UInt64 = cncurses_report_mouse_position()
+  package static let buttonShift: UInt64 = cncurses_button_shift()
+  package static let buttonControl: UInt64 = cncurses_button_ctrl()
+  package static let buttonAlt: UInt64 = cncurses_button_alt()
+
+  package static let button1Pressed: UInt64 = cncurses_button1_pressed()
+  package static let button1Released: UInt64 = cncurses_button1_released()
+  package static let button1Clicked: UInt64 = cncurses_button1_clicked()
+  package static let button1DoubleClicked: UInt64 = cncurses_button1_double_clicked()
+  package static let button1TripleClicked: UInt64 = cncurses_button1_triple_clicked()
+
+  package static let button2Pressed: UInt64 = cncurses_button2_pressed()
+  package static let button2Released: UInt64 = cncurses_button2_released()
+  package static let button2Clicked: UInt64 = cncurses_button2_clicked()
+  package static let button2DoubleClicked: UInt64 = cncurses_button2_double_clicked()
+  package static let button2TripleClicked: UInt64 = cncurses_button2_triple_clicked()
+
+  package static let button3Pressed: UInt64 = cncurses_button3_pressed()
+  package static let button3Released: UInt64 = cncurses_button3_released()
+  package static let button3Clicked: UInt64 = cncurses_button3_clicked()
+  package static let button3DoubleClicked: UInt64 = cncurses_button3_double_clicked()
+  package static let button3TripleClicked: UInt64 = cncurses_button3_triple_clicked()
+
+  package static let button4Pressed: UInt64 = cncurses_button4_pressed()
+  package static let button5Pressed: UInt64 = cncurses_button5_pressed()
+  package static let button6Pressed: UInt64 = cncurses_button6_pressed()
+  package static let button7Pressed: UInt64 = cncurses_button7_pressed()
+}

--- a/Sources/CNCursesSupport/Swift/Runtime.swift
+++ b/Sources/CNCursesSupport/Swift/Runtime.swift
@@ -2,187 +2,190 @@
 import Foundation
 
 #if os(Linux)
-    import Glibc
+  import Glibc
 #else
-    import Darwin.C
+  import Darwin.C
 #endif
 
 /// Errors that can be thrown while configuring the ncurses runtime.
 package enum CNCursesRuntimeError: Error, Equatable {
-    /// Indicates that the process locale could not be configured for wide characters.
-    case localeUnavailable
-    /// The ncurses library failed to produce a usable screen handle.
-    case initializationFailed
-    /// A specific ncurses call returned an error code.
-    case callFailed(name: StaticString, code: Int32)
+  /// Indicates that the process locale could not be configured for wide characters.
+  case localeUnavailable
+  /// The ncurses library failed to produce a usable screen handle.
+  case initializationFailed
+  /// A specific ncurses call returned an error code.
+  case callFailed(name: StaticString, code: Int32)
 
-    package static func == (lhs: CNCursesRuntimeError, rhs: CNCursesRuntimeError) -> Bool {
-        switch (lhs, rhs) {
-        case (.localeUnavailable, .localeUnavailable),
-            (.initializationFailed, .initializationFailed):
-            return true
-        case let (
-            .callFailed(name: lhsName, code: lhsCode), .callFailed(name: rhsName, code: rhsCode)
-        ):
-            return lhsCode == rhsCode && lhsName.asComparableKey == rhsName.asComparableKey
-        default:
-            return false
-        }
+  package static func == (lhs: CNCursesRuntimeError, rhs: CNCursesRuntimeError) -> Bool {
+    switch (lhs, rhs) {
+    case (.localeUnavailable, .localeUnavailable),
+      (.initializationFailed, .initializationFailed):
+      return true
+    case let (
+      .callFailed(name: lhsName, code: lhsCode), .callFailed(name: rhsName, code: rhsCode)
+    ):
+      return lhsCode == rhsCode && lhsName.asComparableKey == rhsName.asComparableKey
+    default:
+      return false
     }
+  }
 }
 
 package enum CNCursesRuntime {
-    private static let state = CNCursesRuntimeState()
+  private static let state = CNCursesRuntimeState()
 
-    /// Prepares the terminal environment for interactive rendering.
-    /// - Returns: `true` when initialization succeeds; otherwise throws.
-    package static func bootstrap() throws -> Bool {
-        try state.bootstrap()
-        return true
-    }
+  /// Prepares the terminal environment for interactive rendering.
+  /// - Returns: `true` when initialization succeeds; otherwise throws.
+  package static func bootstrap() throws -> Bool {
+    try state.bootstrap()
+    return true
+  }
 
-    /// Restores the terminal to its previous state.
-    package static func shutdown() throws {
-        try state.shutdown()
-    }
+  /// Restores the terminal to its previous state.
+  package static func shutdown() throws {
+    try state.shutdown()
+  }
 
-    /// Indicates whether the runtime is operating without a backing terminal.
-    package static var isHeadless: Bool {
-        state.isHeadlessFlag
-    }
+  /// Indicates whether the runtime is operating without a backing terminal.
+  package static var isHeadless: Bool {
+    state.isHeadlessFlag
+  }
 }
 
 private final class CNCursesRuntimeState: @unchecked Sendable {
-    private var screen: CNCursesWindow?
-    private var isHeadless = false
-    private var exitHookRegistered = false
-    private let lock = NSLock()
+  private var screen: CNCursesWindow?
+  private var isHeadless = false
+  private var exitHookRegistered = false
+  private let lock = NSLock()
 
-    func bootstrap() throws {
-        try lock.withLock {
-            if screen != nil || isHeadless {
-                return
-            }
+  func bootstrap() throws {
+    try lock.withLock {
+      if screen != nil || isHeadless {
+        return
+      }
 
-            if !TerminalCapabilities.isInteractive {
-                isHeadless = true
-                return
-            }
+      if !TerminalCapabilities.isInteractive {
+        isHeadless = true
+        return
+      }
 
-            try LocaleConfigurator.ensureWideCharacterLocale()
+      try LocaleConfigurator.ensureWideCharacterLocale()
 
-            let newScreen = try CNCursesWindow.standardScreen()
-            do {
-                try newScreen.prepareForInteractiveUse()
-            } catch {
-                _ = cncurses_endwin()
-                throw error
-            }
+      let newScreen = try CNCursesWindow.standardScreen()
+      do {
+        try newScreen.prepareForInteractiveUse()
+      } catch {
+        _ = cncurses_endwin()
+        throw error
+      }
 
-            screen = newScreen
-            registerExitHookIfNeeded()
-        }
+      screen = newScreen
+      registerExitHookIfNeeded()
     }
+  }
 
-    func shutdown() throws {
-        try lock.withLock {
-            if isHeadless {
-                isHeadless = false
-                return
-            }
+  func shutdown() throws {
+    try lock.withLock {
+      if isHeadless {
+        isHeadless = false
+        return
+      }
 
-            guard screen != nil else {
-                return
-            }
-            try CNCursesCall.check(result: cncurses_endwin(), name: "endwin")
-            screen = nil
-        }
+      guard screen != nil else {
+        return
+      }
+      try CNCursesCall.check(result: cncurses_endwin(), name: "endwin")
+      screen = nil
     }
+  }
 
-    private func registerExitHookIfNeeded() {
-        guard !exitHookRegistered else {
-            return
-        }
-        atexit(swiftCNCursesCleanup)
-        exitHookRegistered = true
+  private func registerExitHookIfNeeded() {
+    guard !exitHookRegistered else {
+      return
     }
+    atexit(swiftCNCursesCleanup)
+    exitHookRegistered = true
+  }
 
-    var isHeadlessFlag: Bool {
-        lock.withLock { isHeadless }
-    }
+  var isHeadlessFlag: Bool {
+    lock.withLock { isHeadless }
+  }
 }
 
 private struct CNCursesWindow {
-    let rawPointer: UnsafeMutableRawPointer
+  let rawPointer: UnsafeMutableRawPointer
 
-    static func standardScreen() throws -> CNCursesWindow {
-        guard let pointer = cncurses_initscr() else {
-            throw CNCursesRuntimeError.initializationFailed
-        }
-        return CNCursesWindow(rawPointer: pointer)
+  static func standardScreen() throws -> CNCursesWindow {
+    guard let pointer = cncurses_initscr() else {
+      throw CNCursesRuntimeError.initializationFailed
     }
+    return CNCursesWindow(rawPointer: pointer)
+  }
 
-    func prepareForInteractiveUse() throws {
-        try CNCursesCall.check(result: cncurses_cbreak(), name: "cbreak")
-        try CNCursesCall.check(result: cncurses_noecho(), name: "noecho")
-        try CNCursesCall.check(result: cncurses_keypad(rawPointer, true), name: "keypad")
-        try CNCursesCall.check(result: cncurses_erase(), name: "erase")
-        try CNCursesCall.check(result: cncurses_refresh(), name: "refresh")
-    }
+  func prepareForInteractiveUse() throws {
+    try CNCursesCall.check(result: cncurses_cbreak(), name: "cbreak")
+    try CNCursesCall.check(result: cncurses_noecho(), name: "noecho")
+    try CNCursesCall.check(result: cncurses_keypad(rawPointer, true), name: "keypad")
+    let descriptor = CNCursesWindowDescriptor(rawValue: rawPointer)
+    try CNCursesInputAPI.enableNonBlockingInput(for: descriptor)
+    CNCursesInputAPI.enableMouseReporting()
+    try CNCursesCall.check(result: cncurses_erase(), name: "erase")
+    try CNCursesCall.check(result: cncurses_refresh(), name: "refresh")
+  }
 }
 
 private enum LocaleConfigurator {
-    static func ensureWideCharacterLocale() throws {
-        #if os(Linux)
-            let result = Glibc.setlocale(LC_ALL, "")
-        #else
-            let result = setlocale(LC_ALL, "")
-        #endif
-        guard result != nil else {
-            throw CNCursesRuntimeError.localeUnavailable
-        }
+  static func ensureWideCharacterLocale() throws {
+    #if os(Linux)
+      let result = Glibc.setlocale(LC_ALL, "")
+    #else
+      let result = setlocale(LC_ALL, "")
+    #endif
+    guard result != nil else {
+      throw CNCursesRuntimeError.localeUnavailable
     }
+  }
 }
 
 package enum CNCursesCall {
-    private static let successCode = cncurses_ok()
+  private static let successCode = cncurses_ok()
 
-    static func check(result: Int32, name: StaticString) throws {
-        if result == successCode {
-            return
-        }
-        throw CNCursesRuntimeError.callFailed(name: name, code: result)
+  static func check(result: Int32, name: StaticString) throws {
+    if result == successCode {
+      return
     }
+    throw CNCursesRuntimeError.callFailed(name: name, code: result)
+  }
 }
 
 private enum TerminalCapabilities {
-    static var isInteractive: Bool {
-        #if os(Linux)
-            return Glibc.isatty(STDIN_FILENO) != 0 && Glibc.isatty(STDOUT_FILENO) != 0
-        #else
-            return isatty(STDIN_FILENO) != 0 && isatty(STDOUT_FILENO) != 0
-        #endif
-    }
+  static var isInteractive: Bool {
+    #if os(Linux)
+      return Glibc.isatty(STDIN_FILENO) != 0 && Glibc.isatty(STDOUT_FILENO) != 0
+    #else
+      return isatty(STDIN_FILENO) != 0 && isatty(STDOUT_FILENO) != 0
+    #endif
+  }
 }
 
 extension NSLock {
-    @inline(__always)
-    fileprivate func withLock<T>(_ body: () throws -> T) rethrows -> T {
-        lock()
-        defer { unlock() }
-        return try body()
-    }
+  @inline(__always)
+  fileprivate func withLock<T>(_ body: () throws -> T) rethrows -> T {
+    lock()
+    defer { unlock() }
+    return try body()
+  }
 }
 
 @_cdecl("swiftCNCursesCleanup")
 private func swiftCNCursesCleanup() {
-    if !cncurses_is_endwin() {
-        _ = cncurses_endwin()
-    }
+  if !cncurses_is_endwin() {
+    _ = cncurses_endwin()
+  }
 }
 
 extension StaticString {
-    fileprivate var asComparableKey: String {
-        String(describing: self)
-    }
+  fileprivate var asComparableKey: String {
+    String(describing: self)
+  }
 }

--- a/Sources/SwiftCursesKit/Runtime/AppContext.swift
+++ b/Sources/SwiftCursesKit/Runtime/AppContext.swift
@@ -1,27 +1,46 @@
 /// Provides runtime information and controls to the active terminal app.
 public struct AppContext: Sendable {
-    private let runtime: TerminalRuntimeCoordinator
-    private let screenBox: TerminalScreen
+  private let runtime: TerminalRuntimeCoordinator
+  private let screenBox: TerminalScreen
+  private let eventSource: TerminalEventSource
 
-    /// Creates a new context with the supplied runtime coordinator and screen.
-    /// - Parameters:
-    ///   - runtime: The coordinator responsible for managing global ncurses state.
-    ///   - screen: The screen presented to the application.
-    internal init(runtime: TerminalRuntimeCoordinator, screen: TerminalScreen) {
-        self.runtime = runtime
-        self.screenBox = screen
-    }
+  /// Creates a new context with the supplied runtime coordinator and screen.
+  /// - Parameters:
+  ///   - runtime: The coordinator responsible for managing global ncurses state.
+  ///   - screen: The screen presented to the application.
+  ///   - eventSource: The event dispatcher responsible for producing runtime events.
+  internal init(
+    runtime: TerminalRuntimeCoordinator, screen: TerminalScreen, eventSource: TerminalEventSource
+  ) {
+    self.runtime = runtime
+    self.screenBox = screen
+    self.eventSource = eventSource
+  }
 
-    /// The root screen associated with the running application.
-    public var screen: TerminalScreen { screenBox }
+  /// The root screen associated with the running application.
+  public var screen: TerminalScreen { screenBox }
 
-    /// Requests termination of the active runtime loop.
-    public func requestShutdown() {
-        runtime.requestShutdown()
-    }
+  /// Provides direct access to the asynchronous stream of runtime events.
+  public var events: EventStream { eventSource.events() }
 
-    /// Asynchronously requests termination of the active runtime loop.
-    public func quit() async {
-        requestShutdown()
-    }
+  /// Requests termination of the active runtime loop.
+  public func requestShutdown() {
+    runtime.requestShutdown()
+  }
+
+  /// Asynchronously requests termination of the active runtime loop.
+  public func quit() async {
+    requestShutdown()
+  }
+
+  /// Schedules periodic tick events to drive animations or background tasks.
+  /// - Parameters:
+  ///   - interval: The cadence between ticks.
+  ///   - immediate: Indicates whether an initial tick should be emitted immediately.
+  /// - Returns: A `Task` handle that can be cancelled to stop the scheduled ticks.
+  @discardableResult
+  public func scheduleTicks(every interval: Duration, immediate: Bool = false) -> Task<Void, Never>
+  {
+    eventSource.scheduleTicks(every: interval, immediate: immediate)
+  }
 }

--- a/Sources/SwiftCursesKit/Runtime/Event.swift
+++ b/Sources/SwiftCursesKit/Runtime/Event.swift
@@ -1,10 +1,194 @@
+import Foundation
+
 /// Represents high-level events delivered to a ``TerminalApp``.
-public enum Event: Sendable {
-    case tick
-    case key(KeyEvent)
+public enum Event: Sendable, Equatable {
+  /// A scheduled timer or animation event.
+  case tick(TickEvent)
+  /// A keyboard input event.
+  case key(KeyEvent)
+  /// A mouse input event.
+  case mouse(MouseEvent)
+  /// A terminal lifecycle or environmental change event.
+  case terminal(TerminalEvent)
+}
+
+/// Describes a scheduled timer callback delivered through ``Event.tick(_:)``.
+public struct TickEvent: Sendable, Equatable {
+  /// A monotonically increasing identifier assigned to each tick.
+  public let sequence: UInt64
+  /// The intended cadence between ticks.
+  public let interval: Duration
+  /// The time at which the tick was emitted.
+  public let timestamp: ContinuousClock.Instant
+
+  /// Creates a new tick representation.
+  /// - Parameters:
+  ///   - sequence: The monotonically increasing sequence number for this tick.
+  ///   - interval: The cadence between successive ticks.
+  ///   - timestamp: The moment at which the tick was generated.
+  public init(sequence: UInt64, interval: Duration, timestamp: ContinuousClock.Instant? = nil) {
+    self.sequence = sequence
+    self.interval = interval
+    self.timestamp = timestamp ?? ContinuousClock().now
+  }
 }
 
 /// Enumerates keyboard-oriented input events.
-public enum KeyEvent: Sendable {
+public struct KeyEvent: Sendable, Equatable {
+  /// Bitset describing key modifiers active during the event.
+  public struct Modifiers: OptionSet, Sendable {
+    public let rawValue: UInt8
+
+    /// Indicates that the Shift key was active.
+    public static let shift = Modifiers(rawValue: 1 << 0)
+    /// Indicates that the Control key was active.
+    public static let control = Modifiers(rawValue: 1 << 1)
+    /// Indicates that the Alt/Option key was active.
+    public static let alt = Modifiers(rawValue: 1 << 2)
+
+    public init(rawValue: UInt8) {
+      self.rawValue = rawValue
+    }
+  }
+
+  /// Represents the semantic meaning of a key event.
+  public enum Key: Sendable, Equatable {
+    /// A printable character, including extended Unicode scalars.
     case character(Character)
+    /// An ASCII control character (for example `^C`).
+    case control(UInt8)
+    /// The Enter or Return key.
+    case enter
+    /// The Tab key.
+    case tab
+    /// The Escape key.
+    case escape
+    /// The Backspace key.
+    case backspace
+    /// Arrow key input.
+    case arrow(Direction)
+    /// Navigational Home key.
+    case home
+    /// Navigational End key.
+    case end
+    /// Page up navigation key.
+    case pageUp
+    /// Page down navigation key.
+    case pageDown
+    /// Insert key.
+    case insert
+    /// Delete key.
+    case delete
+    /// Function key with the supplied index (starting at 1).
+    case function(Int)
+    /// A key that is not yet mapped to a semantic representation.
+    case unknown(code: UInt32)
+  }
+
+  /// Directional arrows produced by arrow keys.
+  public enum Direction: Sendable, Equatable {
+    case up
+    case down
+    case left
+    case right
+  }
+
+  /// The semantic key that was activated.
+  public let key: Key
+
+  /// The modifier flags active for this event.
+  public let modifiers: Modifiers
+
+  /// Creates a key event with the supplied semantics and modifiers.
+  /// - Parameters:
+  ///   - key: The semantic key representation.
+  ///   - modifiers: Active modifier flags. Defaults to none.
+  public init(key: Key, modifiers: Modifiers = []) {
+    self.key = key
+    self.modifiers = modifiers
+  }
+}
+
+/// Represents a pointer interaction received from ncurses.
+public struct MouseEvent: Sendable, Equatable {
+  /// The position in the terminal grid where the event occurred.
+  public struct Location: Sendable, Equatable {
+    public var row: Int
+    public var column: Int
+
+    public init(row: Int, column: Int) {
+      self.row = row
+      self.column = column
+    }
+  }
+
+  /// Indicates which button triggered the event.
+  public enum Button: Sendable, Equatable {
+    case left
+    case middle
+    case right
+    case other(Int)
+  }
+
+  /// Describes the action performed by the mouse input.
+  public enum Action: Sendable, Equatable {
+    case pressed(Button)
+    case released(Button)
+    case clicked(Button, count: Int)
+    case dragged(Button)
+    case scrolled(vertical: Int, horizontal: Int)
+    case moved
+    case unknown(rawState: UInt64)
+  }
+
+  /// Modifiers active during the mouse event.
+  public struct Modifiers: OptionSet, Sendable {
+    public let rawValue: UInt8
+
+    public static let shift = Modifiers(rawValue: 1 << 0)
+    public static let control = Modifiers(rawValue: 1 << 1)
+    public static let alt = Modifiers(rawValue: 1 << 2)
+
+    public init(rawValue: UInt8) {
+      self.rawValue = rawValue
+    }
+  }
+
+  /// The location of the pointer interaction.
+  public let location: Location
+  /// The resolved action associated with the raw mouse state.
+  public let action: Action
+  /// Modifier keys active during the event.
+  public let modifiers: Modifiers
+  /// The raw bitset reported by ncurses for additional processing.
+  public let rawState: UInt64
+
+  /// Creates a new mouse event description.
+  /// - Parameters:
+  ///   - location: Terminal coordinates associated with the event.
+  ///   - action: The resolved mouse action.
+  ///   - modifiers: Active modifier flags.
+  ///   - rawState: The raw ncurses bitset for the event.
+  public init(location: Location, action: Action, modifiers: Modifiers = [], rawState: UInt64) {
+    self.location = location
+    self.action = action
+    self.modifiers = modifiers
+    self.rawState = rawState
+  }
+}
+
+/// Events that describe terminal lifecycle changes.
+public enum TerminalEvent: Sendable, Equatable {
+  case resized(TerminalSize)
+}
+
+/// Represents the current terminal grid dimensions.
+public struct TerminalSize: Sendable, Equatable {
+  public var rows: Int
+  public var columns: Int
+
+  public init(rows: Int, columns: Int) {
+    self.rows = rows
+    self.columns = columns
+  }
 }

--- a/Sources/SwiftCursesKit/Runtime/EventStream.swift
+++ b/Sources/SwiftCursesKit/Runtime/EventStream.swift
@@ -1,0 +1,390 @@
+import CNCursesSupport
+import Foundation
+
+/// An asynchronous stream of terminal ``Event`` values.
+public struct EventStream: AsyncSequence, Sendable {
+  public typealias Element = Event
+
+  private let stream: AsyncStream<Event>
+
+  internal init(stream: AsyncStream<Event>) {
+    self.stream = stream
+  }
+
+  public struct AsyncIterator: AsyncIteratorProtocol {
+    private var iterator: AsyncStream<Event>.AsyncIterator
+
+    fileprivate init(iterator: AsyncStream<Event>.AsyncIterator) {
+      self.iterator = iterator
+    }
+
+    public mutating func next() async -> Event? {
+      await iterator.next()
+    }
+  }
+
+  public func makeAsyncIterator() -> AsyncIterator {
+    AsyncIterator(iterator: stream.makeAsyncIterator())
+  }
+}
+
+/// Coordinates event delivery from ncurses into ``Event`` values.
+final class TerminalEventSource: @unchecked Sendable {
+  private let windowHandle: WindowHandle
+  private let shouldContinue: @Sendable () -> Bool
+  private let clock = ContinuousClock()
+  private let lock = NSLock()
+
+  private let stream: AsyncStream<Event>
+  private var continuation: AsyncStream<Event>.Continuation?
+  private var pollTask: Task<Void, Never>?
+  private var ancillaryTasks: [UUID: Task<Void, Never>] = [:]
+  private var tickSequence: UInt64 = 0
+  private var isStopped = false
+
+  internal init(windowHandle: WindowHandle, shouldContinue: @escaping @Sendable () -> Bool) {
+    self.windowHandle = windowHandle
+    self.shouldContinue = shouldContinue
+    let pair = AsyncStream<Event>.makeStream(of: Event.self)
+    self.stream = pair.stream
+    lock.withLock {
+      continuation = pair.continuation
+    }
+    pair.continuation.onTermination = {
+      [weak self] (_: AsyncStream<Event>.Continuation.Termination) in
+      self?.stop()
+    }
+  }
+
+  func events() -> EventStream {
+    EventStream(stream: stream)
+  }
+
+  func start() {
+    lock.lock()
+    if pollTask != nil || isStopped {
+      lock.unlock()
+      return
+    }
+    lock.unlock()
+
+    let task = Task<Void, Never> { [weak self] in
+      guard let self else { return }
+      await self.pollLoop()
+    }
+
+    lock.withLock {
+      if isStopped {
+        task.cancel()
+      } else {
+        pollTask = task
+      }
+    }
+  }
+
+  func stop() {
+    let (tasks, continuation) = lock.withLock {
+      () -> ([Task<Void, Never>], AsyncStream<Event>.Continuation?) in
+      if isStopped {
+        return ([], nil)
+      }
+      isStopped = true
+      let poll = pollTask
+      pollTask = nil
+      let ancillary = Array(ancillaryTasks.values)
+      ancillaryTasks.removeAll()
+      let continuation = self.continuation
+      self.continuation = nil
+      var tasks: [Task<Void, Never>] = ancillary
+      if let poll {
+        tasks.append(poll)
+      }
+      return (tasks, continuation)
+    }
+    continuation?.finish()
+    for task in tasks {
+      task.cancel()
+    }
+  }
+
+  @discardableResult
+  func scheduleTicks(every interval: Duration, immediate: Bool) -> Task<Void, Never> {
+    let token = UUID()
+    let task = Task { [weak self] in
+      guard let self else { return }
+      defer { self.unregisterAuxiliaryTask(token) }
+      guard !Task.isCancelled, self.shouldContinue() else { return }
+      if immediate {
+        self.emitTick(interval: interval)
+      }
+      while !Task.isCancelled, self.shouldContinue() {
+        do {
+          try await Task.sleep(for: interval)
+        } catch {
+          break
+        }
+        if Task.isCancelled || !self.shouldContinue() {
+          break
+        }
+        self.emitTick(interval: interval)
+      }
+    }
+    registerAuxiliaryTask(task, token: token)
+    return task
+  }
+
+  private func registerAuxiliaryTask(_ task: Task<Void, Never>, token: UUID) {
+    lock.withLock {
+      if isStopped {
+        task.cancel()
+        return
+      }
+      ancillaryTasks[token] = task
+    }
+  }
+
+  private func unregisterAuxiliaryTask(_ token: UUID) {
+    _ = lock.withLock {
+      ancillaryTasks.removeValue(forKey: token)
+    }
+  }
+
+  private func nextTickSequence() -> UInt64 {
+    lock.withLock {
+      tickSequence &+= 1
+      return tickSequence
+    }
+  }
+
+  private func emitTick(interval: Duration) {
+    let sequence = nextTickSequence()
+    emit(.tick(TickEvent(sequence: sequence, interval: interval, timestamp: clock.now)))
+  }
+
+  private func emit(_ event: Event) {
+    _ = lock.withLock {
+      continuation?.yield(event)
+    }
+  }
+
+  private func pollLoop() async {
+    defer { finishStreamIfNeeded() }
+    while shouldContinue(), !Task.isCancelled {
+      guard let descriptor = windowHandle.withDescriptor({ $0 }) else {
+        do {
+          try await Task.sleep(for: .milliseconds(25))
+        } catch {
+          break
+        }
+        continue
+      }
+
+      switch CNCursesInputAPI.readEvent(from: descriptor) {
+      case .none:
+        do {
+          try await Task.sleep(for: .milliseconds(5))
+        } catch {
+          return
+        }
+      case let .character(value):
+        if let key = KeyEvent(unicodeScalarValue: value) {
+          emit(.key(key))
+        }
+      case let .keyCode(code):
+        handleKeyCode(code, descriptor: descriptor)
+      }
+    }
+  }
+
+  private func finishStreamIfNeeded() {
+    let continuation = lock.withLock { () -> AsyncStream<Event>.Continuation? in
+      let existing = self.continuation
+      self.continuation = nil
+      return existing
+    }
+    continuation?.finish()
+  }
+
+  private func handleKeyCode(_ code: UInt32, descriptor: CNCursesWindowDescriptor) {
+    if code == CNCursesKeyCode.mouse {
+      guard let event = CNCursesInputAPI.nextMouseEvent() else { return }
+      emit(.mouse(MouseEvent(from: event)))
+    } else if code == CNCursesKeyCode.resize {
+      let size = CNCursesWindowAPI.size(of: descriptor)
+      emit(.terminal(.resized(TerminalSize(rows: size.rows, columns: size.columns))))
+    } else {
+      emit(.key(KeyEvent(keyCode: code)))
+    }
+  }
+}
+
+extension KeyEvent {
+  fileprivate init?(unicodeScalarValue value: UInt32) {
+    guard let scalar = UnicodeScalar(value) else { return nil }
+    switch scalar.value {
+    case 0x09:
+      self = KeyEvent(key: .tab)
+    case 0x0A, 0x0D:
+      self = KeyEvent(key: .enter)
+    case 0x1B:
+      self = KeyEvent(key: .escape)
+    case 0x7F:
+      self = KeyEvent(key: .backspace)
+    case 0x00...0x1F:
+      self = KeyEvent(key: .control(UInt8(scalar.value)))
+    default:
+      self = KeyEvent(key: .character(Character(scalar)))
+    }
+  }
+
+  fileprivate init(keyCode: UInt32) {
+    if Self.codeIsFunctionKey(keyCode) {
+      let base = Int(keyCode - CNCursesKeyCode.function(0))
+      let index = base > 0 ? base : 0
+      self = KeyEvent(key: .function(index))
+      return
+    }
+
+    switch keyCode {
+    case CNCursesKeyCode.enter:
+      self = KeyEvent(key: .enter)
+    case CNCursesKeyCode.backspace:
+      self = KeyEvent(key: .backspace)
+    case CNCursesKeyCode.up:
+      self = KeyEvent(key: .arrow(.up))
+    case CNCursesKeyCode.down:
+      self = KeyEvent(key: .arrow(.down))
+    case CNCursesKeyCode.left:
+      self = KeyEvent(key: .arrow(.left))
+    case CNCursesKeyCode.right:
+      self = KeyEvent(key: .arrow(.right))
+    case CNCursesKeyCode.home:
+      self = KeyEvent(key: .home)
+    case CNCursesKeyCode.end:
+      self = KeyEvent(key: .end)
+    case CNCursesKeyCode.pageUp:
+      self = KeyEvent(key: .pageUp)
+    case CNCursesKeyCode.pageDown:
+      self = KeyEvent(key: .pageDown)
+    case CNCursesKeyCode.insert:
+      self = KeyEvent(key: .insert)
+    case CNCursesKeyCode.delete:
+      self = KeyEvent(key: .delete)
+    case CNCursesKeyCode.backTab:
+      self = KeyEvent(key: .tab, modifiers: [.shift])
+    default:
+      self = KeyEvent(key: .unknown(code: keyCode))
+    }
+  }
+
+  private static func codeIsFunctionKey(_ code: UInt32) -> Bool {
+    let f1 = CNCursesKeyCode.function(1)
+    let f64 = CNCursesKeyCode.function(64)
+    return code >= f1 && code <= f64
+  }
+}
+
+extension MouseEvent {
+  fileprivate init(from event: CNCursesMouseEvent) {
+    let location = Location(row: Int(event.y), column: Int(event.x))
+    let modifiers = MouseEvent.modifiers(for: event.state)
+    let action = MouseEvent.action(for: event.state)
+    self.init(location: location, action: action, modifiers: modifiers, rawState: event.state)
+  }
+
+  private static func modifiers(for state: UInt64) -> Modifiers {
+    var modifiers: Modifiers = []
+    if state & CNCursesMouseMask.buttonShift != 0 {
+      modifiers.insert(.shift)
+    }
+    if state & CNCursesMouseMask.buttonControl != 0 {
+      modifiers.insert(.control)
+    }
+    if state & CNCursesMouseMask.buttonAlt != 0 {
+      modifiers.insert(.alt)
+    }
+    return modifiers
+  }
+
+  private static func action(for state: UInt64) -> Action {
+    if let action = action(
+      for: state, button: .left, pressed: CNCursesMouseMask.button1Pressed,
+      released: CNCursesMouseMask.button1Released, clicked: CNCursesMouseMask.button1Clicked,
+      doubleClicked: CNCursesMouseMask.button1DoubleClicked,
+      tripleClicked: CNCursesMouseMask.button1TripleClicked)
+    {
+      return action
+    }
+    if let action = action(
+      for: state, button: .middle, pressed: CNCursesMouseMask.button2Pressed,
+      released: CNCursesMouseMask.button2Released, clicked: CNCursesMouseMask.button2Clicked,
+      doubleClicked: CNCursesMouseMask.button2DoubleClicked,
+      tripleClicked: CNCursesMouseMask.button2TripleClicked)
+    {
+      return action
+    }
+    if let action = action(
+      for: state, button: .right, pressed: CNCursesMouseMask.button3Pressed,
+      released: CNCursesMouseMask.button3Released, clicked: CNCursesMouseMask.button3Clicked,
+      doubleClicked: CNCursesMouseMask.button3DoubleClicked,
+      tripleClicked: CNCursesMouseMask.button3TripleClicked)
+    {
+      return action
+    }
+
+    if state & CNCursesMouseMask.button4Pressed != 0 {
+      return .scrolled(vertical: 1, horizontal: 0)
+    }
+    if state & CNCursesMouseMask.button5Pressed != 0 {
+      return .scrolled(vertical: -1, horizontal: 0)
+    }
+    if CNCursesMouseMask.button6Pressed != 0 && state & CNCursesMouseMask.button6Pressed != 0 {
+      return .scrolled(vertical: 0, horizontal: 1)
+    }
+    if CNCursesMouseMask.button7Pressed != 0 && state & CNCursesMouseMask.button7Pressed != 0 {
+      return .scrolled(vertical: 0, horizontal: -1)
+    }
+
+    if state & CNCursesMouseMask.reportPosition != 0 {
+      if state & CNCursesMouseMask.button1Pressed != 0 {
+        return .dragged(.left)
+      }
+      if state & CNCursesMouseMask.button2Pressed != 0 {
+        return .dragged(.middle)
+      }
+      if state & CNCursesMouseMask.button3Pressed != 0 {
+        return .dragged(.right)
+      }
+      return .moved
+    }
+
+    return .unknown(rawState: state)
+  }
+
+  private static func action(
+    for state: UInt64,
+    button: Button,
+    pressed: UInt64,
+    released: UInt64,
+    clicked: UInt64,
+    doubleClicked: UInt64,
+    tripleClicked: UInt64
+  ) -> Action? {
+    if state & pressed != 0 {
+      return .pressed(button)
+    }
+    if state & released != 0 {
+      return .released(button)
+    }
+    if state & tripleClicked != 0 {
+      return .clicked(button, count: 3)
+    }
+    if state & doubleClicked != 0 {
+      return .clicked(button, count: 2)
+    }
+    if state & clicked != 0 {
+      return .clicked(button, count: 1)
+    }
+    return nil
+  }
+}

--- a/Sources/SwiftCursesKit/Runtime/Internal/TerminalRuntimeCoordinator.swift
+++ b/Sources/SwiftCursesKit/Runtime/Internal/TerminalRuntimeCoordinator.swift
@@ -4,118 +4,132 @@ import _Concurrency
 
 /// Coordinates application execution across the ncurses runtime.
 final class TerminalRuntimeCoordinator: @unchecked Sendable {
-    static let shared = TerminalRuntimeCoordinator()
+  static let shared = TerminalRuntimeCoordinator()
 
-    private let lock = NSLock()
-    private var isRunning = false
-    private var shouldStop = false
-    private var screenHandle: WindowHandle?
+  private let lock = NSLock()
+  private var isRunning = false
+  private var shouldStop = false
+  private var screenHandle: WindowHandle?
 
-    private init() {}
+  private init() {}
 
-    func run<App: TerminalApp>(app: App) async throws {
-        var application = app
-        let handle = try start()
-        let screen = TerminalScreen(rootHandle: handle)
-        let context = AppContext(runtime: self, screen: screen)
-        var capturedError: Error?
-        let renderer = SceneRenderer()
+  func run<App: TerminalApp>(app: App) async throws {
+    var application = app
+    let handle = try start()
+    let screen = TerminalScreen(rootHandle: handle)
+    let eventSource = TerminalEventSource(windowHandle: handle) { [weak self] in
+      guard let self else { return false }
+      return self.shouldContinueRunning()
+    }
+    let context = AppContext(runtime: self, screen: screen, eventSource: eventSource)
+    var capturedError: Error?
+    let renderer = SceneRenderer()
 
-        do {
-            while shouldContinueRunning() {
-                try renderer.render(scene: application.body, on: screen)
-                if !shouldContinueRunning() {
-                    break
-                }
-                await application.onEvent(.tick, context: context)
-                if !shouldContinueRunning() {
-                    break
-                }
-                try await Task.sleep(nanoseconds: 50_000_000)
-            }
-        } catch {
-            capturedError = error
+    do {
+      try renderer.render(scene: application.body, on: screen)
+      eventSource.start()
+      let defaultTicker = eventSource.scheduleTicks(every: .milliseconds(50), immediate: true)
+      defer { defaultTicker.cancel() }
+      try await withTaskCancellationHandler {
+        for await event in eventSource.events() {
+          if !shouldContinueRunning() {
+            break
+          }
+          await application.onEvent(event, context: context)
+          if !shouldContinueRunning() {
+            break
+          }
+          try renderer.render(scene: application.body, on: screen)
         }
-
-        do {
-            try stop()
-        } catch {
-            if capturedError == nil {
-                capturedError = error
-            }
-        }
-
-        if let capturedError {
-            throw capturedError
-        }
+      } onCancel: {
+        requestShutdown()
+        eventSource.stop()
+      }
+    } catch {
+      capturedError = error
     }
 
-    func requestShutdown() {
-        lock.withLock { shouldStop = true }
+    eventSource.stop()
+
+    do {
+      try stop()
+    } catch {
+      if capturedError == nil {
+        capturedError = error
+      }
     }
 
-    private func shouldContinueRunning() -> Bool {
-        lock.withLock { !shouldStop }
+    if let capturedError {
+      throw capturedError
     }
+  }
 
-    private func start() throws -> WindowHandle {
-        try lock.withLock {
-            if isRunning {
-                throw TerminalRuntimeError.alreadyRunning
-            }
-            do {
-                _ = try CNCursesRuntime.bootstrap()
-            } catch let error as CNCursesRuntimeError {
-                if case let .callFailed(name: name, code: code) = error {
-                    throw TerminalRuntimeError.ncursesCallFailed(
-                        function: name.runtimeFunctionName, code: code)
-                }
-                throw TerminalRuntimeError.bootstrapFailed
-            } catch {
-                throw TerminalRuntimeError.bootstrapFailed
-            }
-            if CNCursesRuntime.isHeadless {
-                let handle = WindowHandle(descriptor: nil, ownsLifecycle: false)
-                screenHandle = handle
-                shouldStop = false
-                isRunning = true
-                return handle
-            }
-            let descriptor: CNCursesWindowDescriptor
-            do {
-                descriptor = try CNCursesWindowAPI.standardScreen()
-            } catch {
-                try? CNCursesRuntime.shutdown()
-                throw TerminalRuntimeError.bootstrapFailed
-            }
-            let handle = WindowHandle(descriptor: descriptor, ownsLifecycle: false)
-            screenHandle = handle
-            shouldStop = false
-            isRunning = true
-            return handle
-        }
-    }
+  func requestShutdown() {
+    lock.withLock { shouldStop = true }
+  }
 
-    private func stop() throws {
-        let handle: WindowHandle? = lock.withLock {
-            defer {
-                screenHandle = nil
-                shouldStop = false
-                isRunning = false
-            }
-            return screenHandle
+  private func shouldContinueRunning() -> Bool {
+    lock.withLock { !shouldStop }
+  }
+
+  private func start() throws -> WindowHandle {
+    try lock.withLock {
+      if isRunning {
+        throw TerminalRuntimeError.alreadyRunning
+      }
+      do {
+        _ = try CNCursesRuntime.bootstrap()
+      } catch let error as CNCursesRuntimeError {
+        if case let .callFailed(name: name, code: code) = error {
+          throw TerminalRuntimeError.ncursesCallFailed(
+            function: name.runtimeFunctionName, code: code)
         }
-        handle?.markClosed()
-        do {
-            try CNCursesRuntime.shutdown()
-        } catch let error as CNCursesRuntimeError {
-            if case let .callFailed(name: name, code: code) = error {
-                throw TerminalRuntimeError.ncursesCallFailed(
-                    function: name.runtimeFunctionName, code: code)
-            }
-            throw TerminalRuntimeError.bootstrapFailed
-        } catch {
-            throw TerminalRuntimeError.bootstrapFailed
-        }
+        throw TerminalRuntimeError.bootstrapFailed
+      } catch {
+        throw TerminalRuntimeError.bootstrapFailed
+      }
+      if CNCursesRuntime.isHeadless {
+        let handle = WindowHandle(descriptor: nil, ownsLifecycle: false)
+        screenHandle = handle
+        shouldStop = false
+        isRunning = true
+        return handle
+      }
+      let descriptor: CNCursesWindowDescriptor
+      do {
+        descriptor = try CNCursesWindowAPI.standardScreen()
+      } catch {
+        try? CNCursesRuntime.shutdown()
+        throw TerminalRuntimeError.bootstrapFailed
+      }
+      let handle = WindowHandle(descriptor: descriptor, ownsLifecycle: false)
+      screenHandle = handle
+      shouldStop = false
+      isRunning = true
+      return handle
     }
+  }
+
+  private func stop() throws {
+    let handle: WindowHandle? = lock.withLock {
+      defer {
+        screenHandle = nil
+        shouldStop = false
+        isRunning = false
+      }
+      return screenHandle
+    }
+    handle?.markClosed()
+    do {
+      try CNCursesRuntime.shutdown()
+    } catch let error as CNCursesRuntimeError {
+      if case let .callFailed(name: name, code: code) = error {
+        throw TerminalRuntimeError.ncursesCallFailed(
+          function: name.runtimeFunctionName, code: code)
+      }
+      throw TerminalRuntimeError.bootstrapFailed
+    } catch {
+      throw TerminalRuntimeError.bootstrapFailed
+    }
+  }
 }

--- a/Tests/SwiftCursesKitTests/TerminalAppTests.swift
+++ b/Tests/SwiftCursesKitTests/TerminalAppTests.swift
@@ -1,66 +1,64 @@
 import XCTest
+
 @testable import SwiftCursesKit
 
 final class TerminalAppTests: XCTestCase {
-    func testRunReturnsBanner() async throws {
-        let app = StaticTerminalApp()
-        let output = try await app.run()
-        XCTAssertEqual(output, "Test Banner")
-    }
+  func testRunReturnsBanner() async throws {
+    let app = StaticTerminalApp()
+    let output = try await app.run()
+    XCTAssertEqual(output, "Test Banner")
+  }
 
-    func testOnEventReceivesTickAndStops() async throws {
-        let recorder = TickRecorder()
-        let app = CountingTerminalApp(recorder: recorder)
-        _ = try await app.run()
-        let ticks = await recorder.current()
-        XCTAssertEqual(ticks, 1)
-    }
+  func testOnEventReceivesTickAndStops() async throws {
+    let recorder = TickRecorder()
+    let app = CountingTerminalApp(recorder: recorder)
+    _ = try await app.run()
+    let ticks = await recorder.current()
+    XCTAssertEqual(ticks, 1)
+  }
 }
 
 private struct StaticTerminalApp: TerminalApp {
-    var banner: String { "Test Banner" }
+  var banner: String { "Test Banner" }
 
-    var body: some Scene {
-        Screen {
-            Title("Test Banner")
-        }
+  var body: some Scene {
+    Screen {
+      Title("Test Banner")
     }
+  }
 
-    mutating func onEvent(_ event: Event, context: AppContext) async {
-        if case .tick = event {
-            await context.quit()
-        }
+  mutating func onEvent(_ event: Event, context: AppContext) async {
+    if case .tick = event {
+      await context.quit()
     }
+  }
 }
 
 private struct CountingTerminalApp: TerminalApp {
-    var recorder: TickRecorder
+  var recorder: TickRecorder
 
-    var body: some Scene {
-        Screen {
-            Title("Tick Counter")
-        }
+  var body: some Scene {
+    Screen {
+      Title("Tick Counter")
     }
+  }
 
-    mutating func onEvent(_ event: Event, context: AppContext) async {
-        switch event {
-        case .tick:
-            await recorder.increment()
-            await context.quit()
-        default:
-            break
-        }
+  mutating func onEvent(_ event: Event, context: AppContext) async {
+    if case .tick = event {
+      await recorder.increment()
+      await context.quit()
     }
+  }
 }
 
 private actor TickRecorder {
-    private var count = 0
+  private var count = 0
 
-    func increment() {
-        count += 1
-    }
+  func increment() {
+    count += 1
+  }
 
-    func current() -> Int {
-        count
-    }
+  func current() -> Int {
+    count
+  }
 }


### PR DESCRIPTION
## Summary
- expand the ncurses shims and add a Swift input API to decode wide-character key codes and mouse events
- introduce richer Event/KeyEvent/MouseEvent models plus an async EventStream with tick scheduling hooks in AppContext
- update the terminal runtime to iterate the new event stream and adjust tests to match the asynchronous flow

## Testing
- swift build
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68ce6abbee588333aece045b848e4a1d